### PR TITLE
Remove data type parameter from AbstractArray

### DIFF
--- a/src/abstract_register.jl
+++ b/src/abstract_register.jl
@@ -3,12 +3,11 @@ using BitBasis, LegibleLambdas
 export AbstractRegister, @λ, @lambda
 
 """
-    AbstractRegister{B, T}
+    AbstractRegister{B}
 
-Abstract type for quantum registers. `B` is the batch size, `T` is the
-data type.
+Abstract type for quantum registers. `B` is the batch size.
 """
-abstract type AbstractRegister{B, T} end
+abstract type AbstractRegister{B} end
 
 # properties
 """
@@ -46,19 +45,6 @@ Returns the number of batches.
 
 # same with nbatch
 Base.length(r::AbstractRegister{B}) where B = B
-
-"""
-    datatype(register) -> Int
-
-Returns the numerical data type used by register.
-
-!!! note
-
-    `datatype` is not the same with `eltype`, since `AbstractRegister` family
-    is not exactly the same with `AbstractArray`, it is an iterator of several
-    registers.
-"""
-@interface datatype(r::AbstractRegister{B, T}) where {B, T} = T
 
 """
     addbits!(register, n::Int) -> register

--- a/src/adjoint_register.jl
+++ b/src/adjoint_register.jl
@@ -6,7 +6,7 @@ export AdjointRegister
 
 Lazy adjoint for a quantum register.
 """
-struct AdjointRegister{B, T, RT <: AbstractRegister{B, T}} <: AbstractRegister{B, T}
+struct AdjointRegister{B, RT <: AbstractRegister{B}} <: AbstractRegister{B}
     parent::RT
 end
 
@@ -24,6 +24,6 @@ viewbatch(reg::AdjointRegister, i::Int) = adjoint(viewbatch(parent(reg), i))
 
 @forward AdjointRegister.parent nqubits, nremain, nactive
 
-function Base.summary(io::IO, reg::AdjointRegister{B, T, RT}) where {B, T, RT}
+function Base.summary(io::IO, reg::AdjointRegister{B, RT}) where {B, RT}
     print(io, "adjoint(", summary(reg.parent), ")")
 end

--- a/test/abstract_register.jl
+++ b/test/abstract_register.jl
@@ -2,19 +2,19 @@ using YaoBase
 using Test
 
 # mocked registers
-struct TestRegister{B, T} <: AbstractRegister{B, T}
+struct TestRegister{B} <: AbstractRegister{B}
 end
 
-TestRegister() = TestRegister{1, Float64}()
+TestRegister() = TestRegister{1}()
 
 YaoBase.nqubits(::TestRegister) = 8
 YaoBase.nactive(::TestRegister) = 2
 
 export TestInterfaceRegister
-struct TestInterfaceRegister{B, T} <: AbstractRegister{B, T}
+struct TestInterfaceRegister{B} <: AbstractRegister{B}
 end
 
-TestInterfaceRegister() = TestInterfaceRegister{1, Float64}()
+TestInterfaceRegister() = TestInterfaceRegister{1}()
 
 @testset "Test general interface" begin
     @test_throws NotImplementedError nactive(TestInterfaceRegister())
@@ -35,12 +35,12 @@ end
 
 @testset "Test Printing" begin
     @test repr(TestRegister()) == """
-    TestRegister{1,Float64}
+    TestRegister{1}
         active qubits: 2/8"""
 end
 
 @testset "Test adjoint printing" begin
     @test repr(adjoint(TestRegister())) == """
-        adjoint(TestRegister{1,Float64})
+        adjoint(TestRegister{1})
             active qubits: 2/8"""
 end


### PR DESCRIPTION
Remove data type parameter from `AbstractArray`
Note: This is a breaking change.